### PR TITLE
Creates a compact pageview list without websiteUrl

### DIFF
--- a/src/google-analytics.coffee
+++ b/src/google-analytics.coffee
@@ -30,13 +30,27 @@ module.exports = (robot) ->
           service: "analytics"
           version: "v3"
           endpoint: "management.profiles.list"
-          params:                               # parameters to pass to API 
+          params:                               # parameters to pass to API
             accountId: '~all'
             webPropertyId: '~all'
-          callback: (err, data)->               # node-style callback 
+          callback: (err, data)->               # node-style callback
             return console.log(err) if err
             msg.send data.items.map((item)->
               "#{item.name} - #{item.websiteUrl} - #{item.id}"
+            ).join("\n")
+
+    robot.hear /pageviews list compact/i, (msg) ->
+        robot.emit "googleapi:request",
+          service: "analytics"
+          version: "v3"
+          endpoint: "management.profiles.list"
+          params:                               # parameters to pass to API
+            accountId: '~all'
+            webPropertyId: '~all'
+          callback: (err, data)->               # node-style callback
+            return console.log(err) if err
+            msg.send data.items.map((item)->
+              "#{item.name} - #{item.id}"
             ).join("\n")
 
     robot.respond /pageviews\s+(\d+)\s+(\w+)\s*(\w*)/i, (msg) ->
@@ -75,12 +89,12 @@ module.exports = (robot) ->
           service: "analytics"
           version: "v3"
           endpoint: "data.ga.get"
-          params:                               # parameters to pass to API 
+          params:                               # parameters to pass to API
             ids: "ga:#{websiteId}"
             metrics: 'ga:visits, ga:pageviews'
             'start-date': startDate
             'end-date': endDate
-          callback: (err, data)->               # node-style callback 
+          callback: (err, data)->               # node-style callback
             msg.send err if err
             console.log err
             console.log JSON.stringify(data)


### PR DESCRIPTION
Creates the command `pageview list compact`. The original command `pageview list` causes a very long response in Rocket Chat because it gets the metadata of all returned urls, including page title, image, description.. and duplicates all infos in response.
