### PR TITLE
Creates a new command to list a compact profile list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-google-analytics",
   "description": "A Hubot script that queries Google Analytics",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Mostafa Zaher <me@mostafazh.me>",
   "license": "MIT",
   "keywords": [

--- a/src/google-analytics.coffee
+++ b/src/google-analytics.coffee
@@ -6,6 +6,7 @@
 #
 # Commands:
 #   pageviews list - list all Google Analytics profiles accessible.
+#   analytics profiles list - list "id - name" from all Google Analytics profiles accessible.
 #   pageviews 12345678 yesterday - print yesterday's visits and pageviews.
 #   pageviews 12345678 last week - print last week's visits and pageviews.
 #   pageviews 12345678 last month - print last month's visits and pageviews.
@@ -30,13 +31,27 @@ module.exports = (robot) ->
           service: "analytics"
           version: "v3"
           endpoint: "management.profiles.list"
-          params:                               # parameters to pass to API 
+          params:                               # parameters to pass to API
             accountId: '~all'
             webPropertyId: '~all'
-          callback: (err, data)->               # node-style callback 
+          callback: (err, data)->               # node-style callback
             return console.log(err) if err
             msg.send data.items.map((item)->
               "#{item.name} - #{item.websiteUrl} - #{item.id}"
+            ).join("\n")
+
+    robot.hear /analytics profiles list/i, (msg) ->
+        robot.emit "googleapi:request",
+          service: "analytics"
+          version: "v3"
+          endpoint: "management.profiles.list"
+          params:                               # parameters to pass to API
+            accountId: '~all'
+            webPropertyId: '~all'
+          callback: (err, data)->               # node-style callback
+            return console.log(err) if err
+            msg.send data.items.map((item)->
+              "#{item.id} - #{item.name}"
             ).join("\n")
 
     robot.respond /pageviews\s+(\d+)\s+(\w+)\s*(\w*)/i, (msg) ->
@@ -75,12 +90,12 @@ module.exports = (robot) ->
           service: "analytics"
           version: "v3"
           endpoint: "data.ga.get"
-          params:                               # parameters to pass to API 
+          params:                               # parameters to pass to API
             ids: "ga:#{websiteId}"
             metrics: 'ga:visits, ga:pageviews'
             'start-date': startDate
             'end-date': endDate
-          callback: (err, data)->               # node-style callback 
+          callback: (err, data)->               # node-style callback
             msg.send err if err
             console.log err
             console.log JSON.stringify(data)

--- a/src/google-analytics.coffee
+++ b/src/google-analytics.coffee
@@ -49,7 +49,7 @@ module.exports = (robot) ->
             accountId: '~all'
             webPropertyId: '~all'
           callback: (err, data)->               # node-style callback
-            return console.log(err) if err
+            return msg.send(err) if err
             msg.send data.items.map((item)->
               "#{item.id} - #{item.name}"
             ).join("\n")

--- a/test/google-analytics-test.coffee
+++ b/test/google-analytics-test.coffee
@@ -17,3 +17,6 @@ describe 'google-analytics', ->
 
   it 'registers a respond listener', ->
     expect(@robot.respond).to.have.been.calledWith(/pageviews\s+(\d+)\s+(\w+)\s*(\w*)/i)
+
+  it 'registers a hear listener', ->
+    expect(@robot.hear).to.have.been.calledWith(/analytics profiles list/i)


### PR DESCRIPTION
Creates the command `analytics profiles list`. 

Two reasons: 
- The original command `pageviews list` causes a very long response in Rocket Chat because it gets the metadata of all returned urls, including page title, image, description.. and duplicates all infos in response.
- Change the command prefix in a plugin's generic name, allowing expand to other calls to the Google Analytics API. Something like `analytics 12345678 mobile` to get access mobile vs desktop or `analytics 12345678 browser` for most used browsers.
